### PR TITLE
django-newsletter fix error on Message add

### DIFF
--- a/newsletter/admin_forms.py
+++ b/newsletter/admin_forms.py
@@ -175,6 +175,7 @@ class ArticleFormSet(forms.BaseInlineFormSet):
         super().__init__(*args, **kwargs)
 
         assert self.instance
-        next_sortorder = self.instance.get_next_article_sortorder()
-        for index, form in enumerate(self.extra_forms):
-            form.initial['sortorder'] = next_sortorder + index * 10
+        if self.instance.pk:
+            next_sortorder = self.instance.get_next_article_sortorder()
+            for index, form in enumerate(self.extra_forms):
+                form.initial['sortorder'] = next_sortorder + index * 10


### PR DESCRIPTION
Error 
```
Internal Server Error: /admin/newsletter/message/add/
    raise ValueError(
ValueError: 'Message' instance needs to have a primary key value before this relationship can be used.
```